### PR TITLE
83 product variant activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Bundle for https://github.com/chameleon-system/chameleon-base
+Bundle for https://github.com/chameleon-system/chameleon-system

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Bundle for https://github.com/chameleon-system/chameleon-base

--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,14 @@
         "screenshotfolder_id": ""
     },
     "require": {
-        "chameleon-system/chameleon-base": "~6.2.0",
+        "chameleon-system/chameleon-base": "dev-master",
         "simplepie/simplepie": "~1.3"
     },
     "require-dev": {
-        "chameleon-system/code-style-config": "dev-master@dev",
+        "chameleon-system/sanitycheck": "dev-master",
+        "chameleon-system/sanitycheck-bundle": "dev-master",
         "phpunit/dbunit": "~2.0",
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": "~5.0"
     },
     "autoload": {
         "classmap": [

--- a/src/ShopBundle/EventListener/UpdateVariantParentStockListener.php
+++ b/src/ShopBundle/EventListener/UpdateVariantParentStockListener.php
@@ -74,7 +74,7 @@ class UpdateVariantParentStockListener
             $activeValue = $parentProduct->fieldActive;
         }
 
-        if ($parentProduct->fieldActive !== $activeValue) {
+        if ($parentProduct->fieldActive !== $activeValue || $parentProduct->fieldVariantParentIsActive !== $activeValue) {
             $product->setVariantParentActive($parentProduct->id, $activeValue);
         }
     }

--- a/src/ShopBundle/objects/db/TShopArticle.class.php
+++ b/src/ShopBundle/objects/db/TShopArticle.class.php
@@ -1907,6 +1907,8 @@ class TShopArticle extends TShopArticleAutoParent implements ICMSSeoPatternItem,
             return false;
         }
         $oldStock = $this->getAvailableStock();
+        //$valueChanged = (double)$oldStock !== (double)$dNewStockValue;
+        // NOTE the below comparisson always has true as result (compares int to double)
         $stockIsChanging = ($bNewAmountIsDelta || $oldStock !== $dNewStockValue);
         if (false === $stockIsChanging && false === $bUpdateSaleCounter && false === $bForceUpdate) {
             return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#83
| License       | MIT

Two errors fixed when saving the variant product with a stock change: 
- Activation of a variant product (based on the stock)
- "Parent variant active" flag corrected for the main product