### PR TITLE
83 product variant activation 2

### DIFF
--- a/src/ShopBundle/EventListener/UpdateVariantParentStockListener.php
+++ b/src/ShopBundle/EventListener/UpdateVariantParentStockListener.php
@@ -74,7 +74,7 @@ class UpdateVariantParentStockListener
             $activeValue = $parentProduct->fieldActive;
         }
 
-        if ($parentProduct->fieldActive !== $activeValue) {
+        if ($parentProduct->fieldActive !== $activeValue || $parentProduct->fieldVariantParentIsActive !== $activeValue) {
             $product->setVariantParentActive($parentProduct->id, $activeValue);
         }
     }

--- a/src/ShopBundle/objects/TCMSTableEditor/TCMSShopTableEditor_ShopArticle.class.php
+++ b/src/ShopBundle/objects/TCMSTableEditor/TCMSShopTableEditor_ShopArticle.class.php
@@ -115,18 +115,11 @@ class TCMSShopTableEditor_ShopArticle extends TCMSTableEditor
                 $this->oTableConf->SetLanguage($originalLanguageId);
             }
 
-            // The save data for activation (in $this->oTable) might be wrong if a stock was changed in the embedded iframe.
-            $activeNum = $product->CheckActivateOrDeactivate();
-            $shouldBeActive = 1 === $activeNum;
-
-            if ($shouldBeActive !== $productIsActive) {
-                $product->setIsActive($shouldBeActive);
-            }
+            // NOTE the "active" flag of the variant itself is probably wrong here after a stock change
+            //   (old data in $oPostTable->sqlData['active'])
         }
 
         if ($productIsActive) {
-            // NOTE this value might be outdated (changed above)...; see https://github.com/chameleon-system/chameleon-system/issues/84
-
             if (false === $product->fieldVariantParentIsActive) {
                 $this->SaveField('variant_parent_is_active', $oPostTable->sqlData['active']);
             }

--- a/src/ShopBundle/objects/TCMSTableEditor/TCMSShopTableEditor_ShopArticle.class.php
+++ b/src/ShopBundle/objects/TCMSTableEditor/TCMSShopTableEditor_ShopArticle.class.php
@@ -136,7 +136,7 @@ class TCMSShopTableEditor_ShopArticle extends TCMSTableEditor
         }
 
         if ($productIsActive) {
-            // NOTE this value might be outdated (changed above)...
+            // NOTE this value might be outdated (changed above)...; see #84
 
             if (false === $product->fieldVariantParentIsActive) {
                 $this->SaveField('variant_parent_is_active', $oPostTable->sqlData['active']);

--- a/src/ShopBundle/objects/TCMSTableEditor/TCMSShopTableEditor_ShopArticle.class.php
+++ b/src/ShopBundle/objects/TCMSTableEditor/TCMSShopTableEditor_ShopArticle.class.php
@@ -114,7 +114,7 @@ class TCMSShopTableEditor_ShopArticle extends TCMSTableEditor
 
             /*
              * NOTE the "active" flag of the variant itself is probably wrong here after a stock change
-             *   (stock iframe is saved first which may change the active state, POST data of this request 
+             *   (stock iframe is saved first which may change the active state, POST data of this request
              *    contains the old active state)
              */
         }

--- a/src/ShopBundle/objects/TCMSTableEditor/TCMSShopTableEditor_ShopArticle.class.php
+++ b/src/ShopBundle/objects/TCMSTableEditor/TCMSShopTableEditor_ShopArticle.class.php
@@ -59,9 +59,6 @@ class TCMSShopTableEditor_ShopArticle extends TCMSTableEditor
         parent::PostSaveHook($oFields, $oPostTable);
         /** @var TdbShopArticle $product */
         $product = $this->oTable;
-
-        $productIsActive = isset($oPostTable->sqlData['active']) && $oPostTable->sqlData['active'];
-
         if ($product->HasVariants()) {
             $oVariantSet = $product->GetFieldShopVariantSet();
             /** @var $oVariantSet TdbShopVariantSet */
@@ -115,11 +112,14 @@ class TCMSShopTableEditor_ShopArticle extends TCMSTableEditor
                 $this->oTableConf->SetLanguage($originalLanguageId);
             }
 
-            // NOTE the "active" flag of the variant itself is probably wrong here after a stock change
-            //   (old data in $oPostTable->sqlData['active'])
+            /*
+             * NOTE the "active" flag of the variant itself is probably wrong here after a stock change
+             *   (stock iframe is saved first which may change the active state, POST data of this request 
+             *    contains the old active state)
+             */
         }
 
-        if ($productIsActive) {
+        if (isset($oPostTable->sqlData['active']) && $oPostTable->sqlData['active']) {
             if (false === $product->fieldVariantParentIsActive) {
                 $this->SaveField('variant_parent_is_active', $oPostTable->sqlData['active']);
             }

--- a/src/ShopBundle/objects/TCMSTableEditor/TCMSShopTableEditor_ShopArticle.class.php
+++ b/src/ShopBundle/objects/TCMSTableEditor/TCMSShopTableEditor_ShopArticle.class.php
@@ -115,28 +115,17 @@ class TCMSShopTableEditor_ShopArticle extends TCMSTableEditor
                 $this->oTableConf->SetLanguage($originalLanguageId);
             }
 
-            $stockMessage = $product->GetFieldShopStockMessage();
-            if (null !== $stockMessage) {
-                $hasStock = $product->getAvailableStock() > 0;
+            // The save data for activation (in $this->oTable) might be wrong if a stock was changed in the embedded iframe.
+            $activeNum = $product->CheckActivateOrDeactivate();
+            $shouldBeActive = 1 === $activeNum;
 
-                if (true === $hasStock
-                    && true === $stockMessage->fieldAutoActivateOnStock
-                    && false === $productIsActive) {
-
-                    $product->setIsActive(true);
-                }
-
-                if (false === $hasStock
-                    && true === $stockMessage->fieldAutoDeactivateOnZeroStock
-                    && true === $productIsActive) {
-
-                    $product->setIsActive(false);
-                }
+            if ($shouldBeActive !== $productIsActive) {
+                $product->setIsActive($shouldBeActive);
             }
         }
 
         if ($productIsActive) {
-            // NOTE this value might be outdated (changed above)...; see #84
+            // NOTE this value might be outdated (changed above)...; see https://github.com/chameleon-system/chameleon-system/issues/84
 
             if (false === $product->fieldVariantParentIsActive) {
                 $this->SaveField('variant_parent_is_active', $oPostTable->sqlData['active']);

--- a/src/ShopBundle/objects/db/TShopArticle.class.php
+++ b/src/ShopBundle/objects/db/TShopArticle.class.php
@@ -1907,6 +1907,8 @@ class TShopArticle extends TShopArticleAutoParent implements ICMSSeoPatternItem,
             return false;
         }
         $oldStock = $this->getAvailableStock();
+        //$valueChanged = (double)$oldStock !== (double)$dNewStockValue;
+        // NOTE the below comparisson always has true as result (compares int to double)
         $stockIsChanging = ($bNewAmountIsDelta || $oldStock !== $dNewStockValue);
         if (false === $stockIsChanging && false === $bUpdateSaleCounter && false === $bForceUpdate) {
             return false;

--- a/src/ShopBundle/objects/db/TShopArticle.class.php
+++ b/src/ShopBundle/objects/db/TShopArticle.class.php
@@ -1907,8 +1907,7 @@ class TShopArticle extends TShopArticleAutoParent implements ICMSSeoPatternItem,
             return false;
         }
         $oldStock = $this->getAvailableStock();
-        //$valueChanged = (double)$oldStock !== (double)$dNewStockValue;
-        // NOTE the below comparisson always has true as result (compares int to double); see #84
+        // NOTE the below comparisson always has true as result (compares int to double); see https://github.com/chameleon-system/chameleon-system/issues/120
         $stockIsChanging = ($bNewAmountIsDelta || $oldStock !== $dNewStockValue);
         if (false === $stockIsChanging && false === $bUpdateSaleCounter && false === $bForceUpdate) {
             return false;

--- a/src/ShopBundle/objects/db/TShopArticle.class.php
+++ b/src/ShopBundle/objects/db/TShopArticle.class.php
@@ -1907,7 +1907,7 @@ class TShopArticle extends TShopArticleAutoParent implements ICMSSeoPatternItem,
             return false;
         }
         $oldStock = $this->getAvailableStock();
-        // NOTE the below comparisson always has true as result (compares int to double); see https://github.com/chameleon-system/chameleon-system/issues/120
+        // NOTE the below comparison always has true as result (compares int to double); see https://github.com/chameleon-system/chameleon-system/issues/120
         $stockIsChanging = ($bNewAmountIsDelta || $oldStock !== $dNewStockValue);
         if (false === $stockIsChanging && false === $bUpdateSaleCounter && false === $bForceUpdate) {
             return false;

--- a/src/ShopBundle/objects/db/TShopArticle.class.php
+++ b/src/ShopBundle/objects/db/TShopArticle.class.php
@@ -1908,7 +1908,7 @@ class TShopArticle extends TShopArticleAutoParent implements ICMSSeoPatternItem,
         }
         $oldStock = $this->getAvailableStock();
         //$valueChanged = (double)$oldStock !== (double)$dNewStockValue;
-        // NOTE the below comparisson always has true as result (compares int to double)
+        // NOTE the below comparisson always has true as result (compares int to double); see #84
         $stockIsChanging = ($bNewAmountIsDelta || $oldStock !== $dNewStockValue);
         if (false === $stockIsChanging && false === $bUpdateSaleCounter && false === $bForceUpdate) {
             return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#83
| License       | MIT

Two errors fixed when saving the variant product with a stock change: 
- Activation of a variant product (based on the stock)
- "Parent variant active" flag corrected for the main product
