### PR TITLE
ref #195: check access rights before cache

### DIFF
--- a/src/ShopBundle/objects/TCMSSmartURLHandler/TPkgShopRouteControllerArticle.class.php
+++ b/src/ShopBundle/objects/TCMSSmartURLHandler/TPkgShopRouteControllerArticle.class.php
@@ -331,53 +331,54 @@ class TPkgShopRouteControllerArticle extends \esono\pkgCmsRouting\AbstractRouteC
      */
     public function shopCategory(Request $request, $category, $categoryPath, $pagedef)
     {
-        $queryParameter = $request->query->all();
-        if (0 === count($queryParameter)) {
-            $queryParameter = null;
-        }
-        $catPath = $category;
-        $catPrefix = $categoryPath;
-        $tmp = array();
-        if ('' !== $catPrefix) {
-            $tmp[] = $catPrefix;
-        }
-        if ('' !== $catPath) {
-            $tmp[] = $catPath;
-        }
-        $fullPath = '/'.implode('/', $tmp);
-
-        $aKey = array(
-            'class' => __CLASS__,
-            'method' => 'shopCategory',
-            'path' => $catPath,
-        );
-
-        $catPath = rtrim($catPath, '/');
+        $catPath = rtrim($category, '/');
         if ('.html' === substr($catPath, -5) && strlen($catPath) > 5) {
             $catPath = substr($catPath, 0, -5);
         }
 
-        $cache = $this->getCache();
-        $key = $cache->getKey($aKey);
-        $aResponse = $cache->get($key);
-        if (null !== $aResponse) {
-            return $this->processCategoryResponse($aResponse, $request);
-        }
-
-        $aResponse = array(
-            'activeShopArticle' => null,
-            'activeShopCategory' => null,
-            'redirectURL' => null,
-            'redirectPermanent' => false,
-            'noMatch' => false,
-            'pagedef' => $pagedef,
-            'queryParameter' => $queryParameter,
-        );
-
         $oPathCat = TdbShopCategoryList::GetCategoryForCategoryPath(explode('/', $catPath));
+
         if (null !== $oPathCat && true === $oPathCat->AllowDisplayInShop()) {
+            $aKey = array(
+                'class' => __CLASS__,
+                'method' => 'shopCategory',
+                'path' => $category,
+            );
+            $cache = $this->getCache();
+            $key = $cache->getKey($aKey);
+            $aResponse = $cache->get($key);
+            if (null !== $aResponse) {
+                return $this->processCategoryResponse($aResponse, $request);
+            }
+
+            $queryParameter = $request->query->all();
+            if (0 === count($queryParameter)) {
+                $queryParameter = null;
+            }
+
+            $aResponse = array(
+                'activeShopArticle' => null,
+                'activeShopCategory' => null,
+                'redirectURL' => null,
+                'redirectPermanent' => false,
+                'noMatch' => false,
+                'pagedef' => $pagedef,
+                'queryParameter' => $queryParameter,
+            );
+
             // does the URL match?
             $url = $oPathCat->GetLink(false);
+
+            $catPrefix = $categoryPath;
+            $tmp = array();
+            if ('' !== $catPrefix) {
+                $tmp[] = $catPrefix;
+            }
+            if ('' !== $category) {
+                $tmp[] = $category;
+            }
+            $fullPath = '/'.implode('/', $tmp);
+
             if (false === $this->compareRelativeAndPrefixedURL($fullPath, $url)) {
                 $aResponse['redirectURL'] = $oPathCat->GetLink(true);
                 $aResponse['redirectPermanent'] = true;

--- a/src/ShopBundle/objects/db/TShopCategory.class.php
+++ b/src/ShopBundle/objects/db/TShopCategory.class.php
@@ -605,7 +605,7 @@ class TShopCategory extends TShopCategoryAutoParent implements ICMSSeoPatternIte
     }
 
     /**
-     * @return TdbCmsTplPage
+     * @return TdbCmsTplPage|null
      */
     public function getTargetPage()
     {
@@ -630,8 +630,17 @@ class TShopCategory extends TShopCategoryAutoParent implements ICMSSeoPatternIte
             if (null === $activePortal) {
                 return null;
             }
-            $targetPageId = $activePortal->GetSystemPageId('products');
-            $defaultPage = TdbCmsTplPage::GetNewInstance($targetPageId);
+
+            $systemPageService = $this->getSystemPageService();
+            $defaultSystemPage = $systemPageService->getSystemPage('products', $activePortal);
+
+            if (null === $defaultSystemPage) {
+                return null;
+            }
+
+            $pageService = self::getPageService();
+            $defaultPage = $pageService->getById($defaultSystemPage->id);
+
             $targetPage = $defaultPage;
         }
 

--- a/src/ShopBundle/objects/db/TShopCategory.class.php
+++ b/src/ShopBundle/objects/db/TShopCategory.class.php
@@ -20,6 +20,7 @@ class TShopCategory extends TShopCategoryAutoParent implements ICMSSeoPatternIte
 {
     const VIEW_PATH = '/pkgShop/views/db/TShopCategory';
     const FILTER_KEY_NAME = 'cattreeid';
+    const PRODUCTS_PAGE_SYSTEM_NAME = 'products';
 
     /**
      * return the vat group of the category.
@@ -64,9 +65,9 @@ class TShopCategory extends TShopCategoryAutoParent implements ICMSSeoPatternIte
         if (is_null($sLink)) {
             try {
                 if ($bAbsolute) {
-                    $sPageLink = $this->getSystemPageService()->getLinkToSystemPageAbsolute('products', array(), $portal, $language);
+                    $sPageLink = $this->getSystemPageService()->getLinkToSystemPageAbsolute(self::PRODUCTS_PAGE_SYSTEM_NAME, array(), $portal, $language);
                 } else {
-                    $sPageLink = $this->getSystemPageService()->getLinkToSystemPageRelative('products', array(), $portal, $language);
+                    $sPageLink = $this->getSystemPageService()->getLinkToSystemPageRelative(self::PRODUCTS_PAGE_SYSTEM_NAME, array(), $portal, $language);
                 }
                 if ('.html' === substr($sPageLink, -5)) {
                     $sPageLink = substr($sPageLink, 0, -5).'/';
@@ -632,7 +633,7 @@ class TShopCategory extends TShopCategoryAutoParent implements ICMSSeoPatternIte
             }
 
             $systemPageService = $this->getSystemPageService();
-            $defaultSystemPage = $systemPageService->getSystemPage('products', $activePortal);
+            $defaultSystemPage = $systemPageService->getSystemPage(self::PRODUCTS_PAGE_SYSTEM_NAME, $activePortal);
 
             if (null === $defaultSystemPage) {
                 return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no   
| Deprecations? | no
| Tests pass?   | yes   
| Fixed issues  | chameleon-system/chameleon-system#195
| License       | MIT

Before caching the category response, we now check for access rights every time. This way the access right is not being cached independently of the user.

The impact on performance by this additional check is reasonable. We tested this using blackfire as a profiler on a page with 789 categories.
