### PR TITLE
ref #133: Add missing things to make order printing work again

### DIFF
--- a/src/ShopBundle/Resources/config/mappers.xml
+++ b/src/ShopBundle/Resources/config/mappers.xml
@@ -89,5 +89,8 @@
 
         <service id="chameleon_system_shop.mapper.objects.article_list.item_mapper_standard" class="ChameleonSystem\ShopBundle\objects\ArticleList\Mapper\ItemMapperStandard">
         </service>
+
+        <service id="chameleon_system_shop.mapper.view_my_order_details.view_my_order_details_order_object_as_string" class="MTShopViewMyOrderDetailsOrderObjectAsStringMapper">
+        </service>
     </services>
 </container>

--- a/src/ShopBundle/objects/WebModules/ViewMyOrderDetails/MTShopViewMyOrderDetails.php
+++ b/src/ShopBundle/objects/WebModules/ViewMyOrderDetails/MTShopViewMyOrderDetails.php
@@ -14,6 +14,11 @@ use Symfony\Component\HttpFoundation\Request;
 
 class MTShopViewMyOrderDetails extends MTPkgViewRendererAbstractModuleMapper
 {
+    /**
+     * @var string
+     */
+    private $orderIdRequested;
+
     public function Init()
     {
         parent::Init();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#133
| License       | MIT

There were actually 2 problems introduced in 6.2.0:
- The new service ID for the mapper was set in DB, but not defined.
- MTShopViewMyOrderDetails::$orderIdRequested was never declared, but written in MTShopViewMyOrderDetails::Init(). This was a bit unclean in previous versions, but breaks since 6.2.0 as we no longer allow magic setter in modules.