### PR TITLE
260 image hotspots create image crop field and map it

### DIFF
--- a/src/ImageHotspotBundle/mappers/TPkgImageHotspotMapper.class.php
+++ b/src/ImageHotspotBundle/mappers/TPkgImageHotspotMapper.class.php
@@ -76,6 +76,7 @@ class TPkgImageHotspotMapper extends AbstractViewMapper
         $oVisitor->SetMappedValue('sHeadline', $oPkgImageHotspot->fieldName);
 
         $oVisitor->SetMappedValue('sBackgroundImageId', $oActiveItemImage->id);
+        $oVisitor->SetMappedValue('backgroundImageCropId', $oActiveItem->fieldCmsMediaIdImageCropId);
         $oVisitor->SetMappedValue('sBackgroundImageAlt', $oActiveItem->fieldName);
 
         $oNextItem = $oActiveItem->GetNextItem();

--- a/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1546853355.inc.php
+++ b/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1546853355.inc.php
@@ -4,7 +4,7 @@
     - add crop to image field of hotspot item
 </div>
 <?php
-TCMSLogChange::requireBundleUpdates('ImageCropBundle', 1534864767);
+TCMSLogChange::requireBundleUpdates('ChameleonSystemImageCropBundle', 1534864767);
 
 $databaseConnection = TCMSLogChange::getDatabaseConnection();
 
@@ -21,7 +21,7 @@ if (false === $fieldConfigImageField) {
     return;
 }
 
-if ('CMSFIELD_EXTENDEDTABLELIST_MEDIA' !== $fieldConfigImageField['cms_field_type_id']) {
+if (TCMSLogChange::GetFieldType('CMSFIELD_EXTENDEDTABLELIST_MEDIA') !== $fieldConfigImageField['cms_field_type_id']) {
     TCMSLogChange::addInfoMessage(
         'Field type of `cms_media_id` in table `pkg_image_hotspot_item` was apparently changed, please change type to CMSFIELD_EXTENDEDTABLELIST_MEDIA_CROP manually and make sure to keep any custom code. Restrict field to crop preset `pkgImageHotspotItemBackground`.',
         TCMSLogChange::INFO_MESSAGE_LEVEL_ERROR

--- a/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1546853355.inc.php
+++ b/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1546853355.inc.php
@@ -1,0 +1,67 @@
+<h1>Build #1546853355</h1>
+<h2>Date: 2019-01-07</h2>
+<div class="changelog">
+    - add crop to image field of hotspot item
+</div>
+<?php
+TCMSLogChange::requireBundleUpdates('ImageCropBundle', 1534864767);
+
+$databaseConnection = TCMSLogChange::getDatabaseConnection();
+
+$fieldConfigImageField = $databaseConnection->fetchAssoc(
+    'SELECT * FROM `cms_field_conf` WHERE `cms_tbl_conf_id` = ? AND `name` = ?',
+    [TCMSLogChange::GetTableId('pkg_image_hotspot_item'), 'cms_media_id']
+);
+if (false === $fieldConfigImageField) {
+    TCMSLogChange::addInfoMessage(
+        'Field `cms_media_id` in table `pkg_image_hotspot_item` is missing.',
+        TCMSLogChange::INFO_MESSAGE_LEVEL_ERROR
+    );
+
+    return;
+}
+
+if ('CMSFIELD_EXTENDEDTABLELIST_MEDIA' !== $fieldConfigImageField['cms_field_type_id']) {
+    TCMSLogChange::addInfoMessage(
+        'Field type of `cms_media_id` in table `pkg_image_hotspot_item` was apparently changed, please change type to CMSFIELD_EXTENDEDTABLELIST_MEDIA_CROP manually and make sure to keep any custom code. Restrict field to crop preset `pkgImageHotspotItemBackground`.',
+        TCMSLogChange::INFO_MESSAGE_LEVEL_ERROR
+    );
+
+    return;
+}
+
+$query = 'ALTER TABLE `pkg_image_hotspot_item` ADD `cms_media_id_image_crop_id` CHAR(36) CHARACTER SET latin1 COLLATE latin1_general_ci NOT NULL';
+TCMSLogChange::RunQuery(__LINE__, $query);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
+    ->setFields(
+        [
+            'cms_field_type_id' => TCMSLogChange::GetFieldType('CMSFIELD_EXTENDEDTABLELIST_MEDIA_CROP'),
+            'fieldtype_config' => 'bShowCategorySelector=1
+imageCropPresetSystemName=pkgImageHotspotItemBackground
+imageCropPresetRestrictionSystemNames=pkgImageHotspotItemBackground',
+        ]
+    )
+    ->setWhereEquals(
+        [
+            'id' => $fieldConfigImageField['id'],
+        ]
+    );
+TCMSLogChange::update(__LINE__, $data);
+
+$query = 'ALTER TABLE `pkg_image_hotspot_item` ADD INDEX ( `cms_media_id_image_crop_id` )';
+TCMSLogChange::RunQuery(__LINE__, $query);
+
+$highestPosition = (int) $databaseConnection->fetchColumn('SELECT MAX(`position`) FROM `cms_image_crop_preset`');
+$data = TCMSLogChange::createMigrationQueryData('cms_image_crop_preset', 'de')
+    ->setFields(
+        [
+            'name' => 'Image-Hotspot: Hintergrundbild',
+            'width' => '1170',
+            'height' => '385',
+            'system_name' => 'pkgImageHotspotItemBackground',
+            'position' => $highestPosition++,
+            'id' => TCMSLogChange::createUnusedRecordId('cms_image_crop_preset'),
+        ]
+    );
+TCMSLogChange::insert(__LINE__, $data);

--- a/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1546853355.inc.php
+++ b/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1546853355.inc.php
@@ -33,7 +33,7 @@ if (TCMSLogChange::GetFieldType('CMSFIELD_EXTENDEDTABLELIST_MEDIA') !== $fieldCo
 $query = 'ALTER TABLE `pkg_image_hotspot_item` ADD `cms_media_id_image_crop_id` CHAR(36) CHARACTER SET latin1 COLLATE latin1_general_ci NOT NULL';
 TCMSLogChange::RunQuery(__LINE__, $query);
 
-$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'de')
+$data = TCMSLogChange::createMigrationQueryData('cms_field_conf', 'en')
     ->setFields(
         [
             'cms_field_type_id' => TCMSLogChange::GetFieldType('CMSFIELD_EXTENDEDTABLELIST_MEDIA_CROP'),
@@ -53,15 +53,26 @@ $query = 'ALTER TABLE `pkg_image_hotspot_item` ADD INDEX ( `cms_media_id_image_c
 TCMSLogChange::RunQuery(__LINE__, $query);
 
 $highestPosition = (int) $databaseConnection->fetchColumn('SELECT MAX(`position`) FROM `cms_image_crop_preset`');
-$data = TCMSLogChange::createMigrationQueryData('cms_image_crop_preset', 'de')
+$newPresetId = TCMSLogChange::createUnusedRecordId('cms_image_crop_preset');
+
+$data = TCMSLogChange::createMigrationQueryData('cms_image_crop_preset', 'en')
     ->setFields(
         [
-            'name' => 'Image-Hotspot: Hintergrundbild',
+            'name' => 'Presenter with hotspots: Background image',
             'width' => '1170',
             'height' => '385',
             'system_name' => 'pkgImageHotspotItemBackground',
             'position' => $highestPosition++,
-            'id' => TCMSLogChange::createUnusedRecordId('cms_image_crop_preset'),
+            'id' => $newPresetId,
         ]
     );
 TCMSLogChange::insert(__LINE__, $data);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_image_crop_preset', 'de')
+    ->setFields(
+        [
+            'name' => 'Presenter mit Hotspots: Hintergrundbild',
+        ]
+    )
+    ->setWhereEquals(['id' => $newPresetId]);
+TCMSLogChange::update(__LINE__, $data);


### PR DESCRIPTION
…pot mapper

| Q             | A
| ------------- | ---
| Branch        |  master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed issues  | chameleon-system/chameleon-system#260
| License       | MIT

Adding an image crop field for image hotspots in preparation for https://github.com/chameleon-system/chameleon-shop-theme-bundle/issues/16

ATTENTION: This PR requires the ImageCropBundle to be integrated in chameleon-base. 