### PR TITLE
ref #16: fix name of image crop preset after field was made multilingual

### DIFF
--- a/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1552666351.inc.php
+++ b/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1552666351.inc.php
@@ -1,0 +1,23 @@
+<h1>Build #1552666351</h1>
+<h2>Date: 2019-03-15</h2>
+<div class="changelog">
+    - fix name of image crop preset after field was made multilingual
+</div>
+<?php
+TCMSLogChange::requireBundleUpdates('ChameleonSystemImageCropBundle', 1552663534);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_image_crop_preset', 'en')
+    ->setFields(
+        [
+            'name' => 'Presenter with hotspots: Background image',
+        ]
+    )->setWhereEquals(['system_name' => 'pkgImageHotspotItemBackground']);
+TCMSLogChange::update(__LINE__, $data);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_image_crop_preset', 'de')
+    ->setFields(
+        [
+            'name' => 'Presenter mit Hotspots: Hintergrundbild',
+        ]
+    )->setWhereEquals(['system_name' => 'pkgImageHotspotItemBackground']);
+TCMSLogChange::update(__LINE__, $data);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-shop-theme-bundle#16
| License       | MIT

chameleon-system/chameleon-base#263 needs to be merged before this.

