### PR TITLE
ref #497: Correct exception type for orderStatusAddedHook

### DIFF
--- a/src/ShopPaymentTransactionBundle/exceptions/TPkgShopPaymentTransactionException_PaymentHandlerDoesNotSupportTransaction.class.php
+++ b/src/ShopPaymentTransactionBundle/exceptions/TPkgShopPaymentTransactionException_PaymentHandlerDoesNotSupportTransaction.class.php
@@ -9,6 +9,6 @@
  * file that was distributed with this source code.
  */
 
-class TPkgShopPaymentTransactionException_PaymentHandlerDoesNotSupportTransaction extends \Exception
+class TPkgShopPaymentTransactionException_PaymentHandlerDoesNotSupportTransaction extends \TPkgCmsException
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#497
| License       | MIT
