### PR TITLE
Use placeholder to set hidden basket button fields

### DIFF
--- a/src/ShopBundle/Basket/BasketVariableReplacer.php
+++ b/src/ShopBundle/Basket/BasketVariableReplacer.php
@@ -72,7 +72,10 @@ final class BasketVariableReplacer
             );
             \TTools::AddStaticPageVariables([self::BASKET_HIDDEN_FIELDS_PLACEHOLDER => $hiddenFieldsHtml]);
         } catch(Error $error) {
-            $this->logger->error('Error rendering hidden fields for basket forms: ' . $error->getMessage());
+            $this->logger->error(
+                sprintf('Error rendering hidden fields for basket forms: %s', $error->getMessage()),
+                ['exception' => $error]
+            );
         }
     }
 

--- a/src/ShopBundle/Basket/BasketVariableReplacer.php
+++ b/src/ShopBundle/Basket/BasketVariableReplacer.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Chameleon System (https://www.chameleonsystem.com).
+ *
+ * (c) ESONO AG (https://www.esono.de)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ChameleonSystem\ShopBundle\Basket;
+
+use ChameleonSystem\CoreBundle\Response\ResponseVariableReplacerInterface;
+use Monolog\Logger;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Environment;
+use Twig\Error\Error;
+
+/**
+ * BasketVariableReplacer is used to add all request parameters as hidden fields to "Add to Basket"-forms.
+ * This happens as a post process job to avoid caching those parameters.
+ *
+ * To successfully use it on a page the template for the basket button must include a placeholder in the form of:
+ *
+ * [{BASKETHIDDENFIELDS}]
+ *
+ * Background: the additional fields are added so that those parameters from the url do not get lost on the redirect
+ * after the POST call to the server.
+ * As we do not know which parameters might be needed by other modules on the page we must add all of them.
+ * This isn't a security concern as the page has already been called with those parameters in the first place.
+ */
+final class BasketVariableReplacer
+{
+    public const BASKET_HIDDEN_FIELDS_PLACEHOLDER = 'BASKETHIDDENFIELDS';
+    private const HIDDEN_FIELDS_SNIPPET = '@ChameleonSystemShop/snippets/ShopBundle/BasketForm/hiddenBasketFields.html.twig';
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+    /**
+     * @var Environment
+     */
+    private $twigEnvironment;
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+    public function __construct(
+        RequestStack $requestStack,
+        Environment $twigEnvironment,
+        Logger $logger)
+    {
+        $this->requestStack = $requestStack;
+        $this->twigEnvironment = $twigEnvironment;
+        $this->logger = $logger;
+    }
+
+    /**
+     * handleRequest will be invoked on kernel.request and add the hidden fields to the replacer.
+     * On error it will log to the request channel and move on. It will not halt execution.
+     */
+    public function handleRequest(): void
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            $this->logger->addError('Tried to get the current request, but there was none. Additional hidden fields for the basket form will not be added.');
+            return;
+        }
+        $queryParameters = $request->query->all();
+        try {
+            $hiddenFieldsHtml = $this->twigEnvironment->render(
+                self::HIDDEN_FIELDS_SNIPPET,
+                ['values' => $queryParameters]
+            );
+            \TTools::AddStaticPageVariables([self::BASKET_HIDDEN_FIELDS_PLACEHOLDER => $hiddenFieldsHtml]);
+        } catch(Error $error) {
+            $this->logger->addError('Error rendering hidden fields for basket forms: ' . $error->getMessage());
+        }
+    }
+}

--- a/src/ShopBundle/Basket/BasketVariableReplacer.php
+++ b/src/ShopBundle/Basket/BasketVariableReplacer.php
@@ -11,8 +11,7 @@
 
 namespace ChameleonSystem\ShopBundle\Basket;
 
-use ChameleonSystem\CoreBundle\Response\ResponseVariableReplacerInterface;
-use Monolog\Logger;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Error\Error;
@@ -44,14 +43,14 @@ final class BasketVariableReplacer
      */
     private $twigEnvironment;
     /**
-     * @var Logger
+     * @var LoggerInterface
      */
     private $logger;
 
     public function __construct(
         RequestStack $requestStack,
         Environment $twigEnvironment,
-        Logger $logger)
+        LoggerInterface $logger)
     {
         $this->requestStack = $requestStack;
         $this->twigEnvironment = $twigEnvironment;
@@ -66,7 +65,7 @@ final class BasketVariableReplacer
     {
         $request = $this->requestStack->getCurrentRequest();
         if (null === $request) {
-            $this->logger->addError('Tried to get the current request, but there was none. Additional hidden fields for the basket form will not be added.');
+            $this->logger->error('Tried to get the current request, but there was none. Additional hidden fields for the basket form will not be added.');
             return;
         }
         $queryParameters = $request->query->all();
@@ -77,7 +76,7 @@ final class BasketVariableReplacer
             );
             \TTools::AddStaticPageVariables([self::BASKET_HIDDEN_FIELDS_PLACEHOLDER => $hiddenFieldsHtml]);
         } catch(Error $error) {
-            $this->logger->addError('Error rendering hidden fields for basket forms: ' . $error->getMessage());
+            $this->logger->error('Error rendering hidden fields for basket forms: ' . $error->getMessage());
         }
     }
 }

--- a/src/ShopBundle/Basket/BasketVariableReplacer.php
+++ b/src/ShopBundle/Basket/BasketVariableReplacer.php
@@ -62,7 +62,7 @@ final class BasketVariableReplacer
     {
         $request = $event->getRequest();
         $queryParameters = $request->query->all();
-        $paramsToRender = $this->filterKeys($queryParameters, ['basket']);
+        $paramsToRender = $this->filterKeys($queryParameters, [\MTShopBasketCoreEndpoint::URL_REQUEST_PARAMETER]);
         $paramsToRender = $this->flattenQueryParameters($paramsToRender);
 
         try {

--- a/src/ShopBundle/Basket/BasketVariableReplacer.php
+++ b/src/ShopBundle/Basket/BasketVariableReplacer.php
@@ -13,6 +13,7 @@ namespace ChameleonSystem\ShopBundle\Basket;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Twig\Environment;
 use Twig\Error\Error;
 
@@ -35,10 +36,6 @@ final class BasketVariableReplacer
     private const HIDDEN_FIELDS_SNIPPET = '@ChameleonSystemShop/snippets/ShopBundle/BasketForm/hiddenBasketFields.html.twig';
 
     /**
-     * @var RequestStack
-     */
-    private $requestStack;
-    /**
      * @var Environment
      */
     private $twigEnvironment;
@@ -48,11 +45,9 @@ final class BasketVariableReplacer
     private $logger;
 
     public function __construct(
-        RequestStack $requestStack,
         Environment $twigEnvironment,
         LoggerInterface $logger)
     {
-        $this->requestStack = $requestStack;
         $this->twigEnvironment = $twigEnvironment;
         $this->logger = $logger;
     }
@@ -60,14 +55,12 @@ final class BasketVariableReplacer
     /**
      * handleRequest will be invoked on kernel.request and add the hidden fields to the replacer.
      * On error it will log to the request channel and move on. It will not halt execution.
+     *
+     * @param GetResponseEvent $event
      */
-    public function handleRequest(): void
+    public function handleRequest(GetResponseEvent $event): void
     {
-        $request = $this->requestStack->getCurrentRequest();
-        if (null === $request) {
-            $this->logger->error('Tried to get the current request, but there was none. Additional hidden fields for the basket form will not be added.');
-            return;
-        }
+        $request = $event->getRequest();
         $queryParameters = $request->query->all();
         try {
             $hiddenFieldsHtml = $this->twigEnvironment->render(

--- a/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1588073204.inc.php
+++ b/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1588073204.inc.php
@@ -5,4 +5,4 @@
 </div>
 <?php
 
-TCMSLogChange::addInfoMessage('If you are using a custom theme you need to add a new placeholder to the twig file(s) rendering an add-to-basket button: [{BASKETHIDDENFIELDS}]. See \ChameleonSystem\ShopBundle\Basket\BasketVariableReplacer for more details.');
+TCMSLogChange::addInfoMessage('If you are using a custom theme you need to add a new placeholder to the twig file(s) rendering an add-to-basket button: [{BASKETHIDDENFIELDS}]. See \ChameleonSystem\ShopBundle\Basket\BasketVariableReplacer for more details.', TCMSLogChange::INFO_MESSAGE_LEVEL_WARNING);

--- a/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1588073204.inc.php
+++ b/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1588073204.inc.php
@@ -1,0 +1,8 @@
+<h1>Build #1588073204</h1>
+<h2>Date: 2020-04-28</h2>
+<div class="changelog">
+    - Add message about new placeholder for basket buttons
+</div>
+<?php
+
+TCMSLogChange::addInfoMessage('If you are using a custom theme you need to add a new placeholder to the twig file(s) rendering an add-to-basket button: [{BASKETHIDDENFIELDS}]. See \ChameleonSystem\ShopBundle\Basket\BasketVariableReplacer for more details.');

--- a/src/ShopBundle/Resources/config/services.xml
+++ b/src/ShopBundle/Resources/config/services.xml
@@ -279,6 +279,7 @@
         <service
                 id="chameleon_system_shop.basket.basket_variable_replacer"
                 class="ChameleonSystem\ShopBundle\Basket\BasketVariableReplacer"
+                public="true"
         >
             <argument type="service" id="twig"/>
             <argument type="service" id="logger" on-invalid="ignore"/>

--- a/src/ShopBundle/Resources/config/services.xml
+++ b/src/ShopBundle/Resources/config/services.xml
@@ -276,6 +276,17 @@
         <service id="chameleon_system_shop.product_variant_service" class="ChameleonSystem\ShopBundle\Service\ProductVariantService">
         </service>
 
+        <service
+                id="chameleon_system_shop.basket.basket_variable_replacer"
+                class="ChameleonSystem\ShopBundle\Basket\BasketVariableReplacer"
+        >
+            <argument type="service" id="request_stack"/>
+            <argument type="service" id="twig"/>
+            <argument type="service" id="logger" on-invalid="ignore"/>
+            <tag name="monolog.logger" channel="request"/>
+            <tag name="kernel.event_listener" event="kernel.request" method="handleRequest" priority="253"/>
+        </service>
+
     </services>
 
 </container>

--- a/src/ShopBundle/Resources/config/services.xml
+++ b/src/ShopBundle/Resources/config/services.xml
@@ -280,7 +280,6 @@
                 id="chameleon_system_shop.basket.basket_variable_replacer"
                 class="ChameleonSystem\ShopBundle\Basket\BasketVariableReplacer"
         >
-            <argument type="service" id="request_stack"/>
             <argument type="service" id="twig"/>
             <argument type="service" id="logger" on-invalid="ignore"/>
             <tag name="monolog.logger" channel="request"/>

--- a/src/ShopBundle/Resources/views/snippets/ShopBundle/BasketForm/hiddenBasketFields.html.twig
+++ b/src/ShopBundle/Resources/views/snippets/ShopBundle/BasketForm/hiddenBasketFields.html.twig
@@ -1,0 +1,3 @@
+{% for name, value in values %}
+<input type="hidden" name="{{name | e('html_attr')}}" value="{{value | e('html_attr')}}" />
+{% endfor %}

--- a/src/ShopBundle/mappers/basket/TPkgShopMapper_ArticleAddToBasket.class.php
+++ b/src/ShopBundle/mappers/basket/TPkgShopMapper_ArticleAddToBasket.class.php
@@ -41,7 +41,7 @@ class TPkgShopMapper_ArticleAddToBasket extends AbstractViewMapper
         $bRedirectToBasket = $oVisitor->GetSourceObject('bRedirectToBasket');
 
         $oVisitor->SetMappedValue('sAddToBasketLink', $oArticle->GetToBasketLink(false, $bRedirectToBasket, false, false, MTShopBasketCore::MSG_CONSUMER_NAME));
-        $aBasketParameters = $oArticle->GetToBasketLinkParameters($bRedirectToBasket, false, false, MTShopBasketCore::MSG_CONSUMER_NAME);
+        $aBasketParameters = $oArticle->GetToBasketLinkBasketParameters($bRedirectToBasket, false, false, MTShopBasketCore::MSG_CONSUMER_NAME);
         unset($aBasketParameters[MTShopBasketCore::URL_REQUEST_PARAMETER][MTShopBasketCore::URL_ITEM_AMOUNT_NAME]);
         $sAddToBasketHiddenFields = TTools::GetArrayAsFormInput($aBasketParameters);
         $oVisitor->SetMappedValue('sAddToBasketHiddenFields', $sAddToBasketHiddenFields);


### PR DESCRIPTION
To avoid caching of those parameters we add them in a post process step

| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | maybe, but not critical. See below.
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#582
| License       | MIT

Currently all request parameters are added as hidden fields to add-to-basket forms. When enabling cache, those parameters will be part of the created cache. To avoid this, there is a new post processing step, that will replace the placeholder `[{BASKETHIDDENFIELDS}]` in the HTML with hidden fields of all request parameters. This way, only the placeholder will be cached and replaced with the current values on every call.

Existing systems with custom themes need to add the placeholder to their templates. This can be considered a BC break, but the only reason those parameters are being added is to avoid losing them on the redirect after the article is added to the basket and only if this is happening using a POST request instead of using an ajax call.

Caching those parameters can be harmful - albeit very unlikely to be used maliciously - so patching this in a patch release seems reasonable, even if users might have to augment their code after updating.

