### PR TITLE
Add internal state for voucher list

### DIFF
--- a/src/ShopBundle/objects/TShopBasket/TShopBasketCore.class.php
+++ b/src/ShopBundle/objects/TShopBasket/TShopBasketCore.class.php
@@ -755,6 +755,11 @@ class TShopBasketCore implements IDataExtranetUserObserver, IPkgCmsSessionPostWa
         $this->RecalculateVAT();
         $this->dCostTotal = $this->dCostArticlesTotalAfterDiscounts + $this->dCostShipping + $this->dCostPaymentMethodSurcharge;
         $this->RecalculateVouchers();
+        // Since vouchers are recalculated twice, we need to remember all calls to RemoveInvalidVouchers internally to not
+        // check valid vouchers twice.
+        // At this point we are done with all recalculations and can tell the voucher list to reset its internal state to be ready
+        // for the next time vouchers are being recalculated.
+        $this->GetActiveVouchers()->allRemoveRunsDone();
         $this->dCostTotal = $this->dCostTotal - $this->dCostVouchers; // - $this->dCostDiscounts;
         $this->dCostTotalWithoutShipping = $this->dCostTotal - $this->dCostShipping;
 

--- a/src/ShopBundle/objects/TShopBasket/TShopBasketVoucherCoreList.class.php
+++ b/src/ShopBundle/objects/TShopBasket/TShopBasketVoucherCoreList.class.php
@@ -12,7 +12,7 @@
 class TShopBasketVoucherCoreList extends TIterator
 {
 
-    protected $checkedAndValid = [];
+    private $checkedAndValid = [];
 
     /**
      * Adds a voucher to the list. note that it wil not check if the voucher is valid (this must be done by the calling method)


### PR DESCRIPTION
Fix #540

| Q             | A
| ------------- | ---
| Branch        | 6.2.x 
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no     
| Deprecations? | no 
| Tests pass?   | yes   
| Fixed issues  | chameleon-system/chameleon-system#540
| License       | MIT

The voucher list now holds an internal state to avoid double checking already checked and valid vouchers. This is not the prettiest fix but we need to hold this state internally as some code assumes the list to be the same as the active list in the current basket. That's the reason why the last fix crashed the system under certain circumstances. While the idea to use different voucher lists for the different types of vouchers was good, the implementation of some validation checks conflicted with this idea. So the new approach can be reviewed here.

