### PR TITLE
set active voucher type to filter inside the list

### DIFF
--- a/src/ShopBundle/objects/TShopBasket/TShopBasketCore.class.php
+++ b/src/ShopBundle/objects/TShopBasket/TShopBasketCore.class.php
@@ -202,6 +202,12 @@ class TShopBasketCore implements IDataExtranetUserObserver, IPkgCmsSessionPostWa
      */
     const SESSION_KEY_LAST_CREATED_ORDER_ID = 'basketobjectlastorderid';
 
+    public const VOUCHER_TYPE_NOT_SET = -1;
+    public const VOUCHER_SPONSORED = 0;
+    public const VOUCHER_NOT_SPONSORED = 1;
+
+    private $voucherTypeCurrentlyRecalculating = self::VOUCHER_TYPE_NOT_SET;
+
     /**
      * if set to true, the basket will recalculate its contents on destruction or reinitialization
      * use SetBasketRecalculationFlag and BasketRequiresRecalculation to access.
@@ -746,7 +752,13 @@ class TShopBasketCore implements IDataExtranetUserObserver, IPkgCmsSessionPostWa
         $this->reloadVouchers();
 
         // now calculate the voucher values that act as discounts (vouchers NOT sponsored)
+        // We need to set the type here because the current method to remove invalid vouchers does not take a type which
+        // we can use to filter the vouchers being recalculated at the moment.
+        // This fixes https://github.com/chameleon-system/chameleon-system/issues/540
+        $this->setVoucherTypeCurrentlyRecalculating(self::VOUCHER_NOT_SPONSORED);
         $this->RecalculateNoneSponsoredVouchers();
+        $this->setVoucherTypeCurrentlyRecalculating(self::VOUCHER_TYPE_NOT_SET);
+
         $this->dCostArticlesTotalAfterDiscounts = $this->dCostArticlesTotalAfterDiscounts - $this->dCostNoneSponsoredVouchers;
 
         $this->RecalculateShipping();
@@ -754,12 +766,9 @@ class TShopBasketCore implements IDataExtranetUserObserver, IPkgCmsSessionPostWa
 
         $this->RecalculateVAT();
         $this->dCostTotal = $this->dCostArticlesTotalAfterDiscounts + $this->dCostShipping + $this->dCostPaymentMethodSurcharge;
+        $this->setVoucherTypeCurrentlyRecalculating(self::VOUCHER_SPONSORED);
         $this->RecalculateVouchers();
-        // Since vouchers are recalculated twice, we need to remember all calls to RemoveInvalidVouchers internally to not
-        // check valid vouchers twice.
-        // At this point we are done with all recalculations and can tell the voucher list to reset its internal state to be ready
-        // for the next time vouchers are being recalculated.
-        $this->GetActiveVouchers()->allRemoveRunsDone();
+        $this->setVoucherTypeCurrentlyRecalculating(self::VOUCHER_TYPE_NOT_SET);
         $this->dCostTotal = $this->dCostTotal - $this->dCostVouchers; // - $this->dCostDiscounts;
         $this->dCostTotalWithoutShipping = $this->dCostTotal - $this->dCostShipping;
 
@@ -981,7 +990,6 @@ class TShopBasketCore implements IDataExtranetUserObserver, IPkgCmsSessionPostWa
         if (!is_null($this->GetActiveVouchers())) {
             $this->dCostNoneSponsoredVouchers = 0;
             $this->GetActiveVouchers()->RemoveInvalidVouchers(MTShopBasketCore::MSG_CONSUMER_NAME, $this);
-
             $this->dCostNoneSponsoredVouchers = $this->GetActiveVouchers()->GetVoucherValue(false);
             if ($this->dCostNoneSponsoredVouchers > $this->dCostArticlesTotalAfterDiscounts) {
                 $this->dCostNoneSponsoredVouchers = $this->dCostArticlesTotalAfterDiscounts;
@@ -1497,6 +1505,18 @@ class TShopBasketCore implements IDataExtranetUserObserver, IPkgCmsSessionPostWa
         return $this->oBasketArticles;
     }
 
+    /**
+     * @return int - TShopBasketCore::VOUCHER_TYPE_NOT_SET|TShopBasketCore::VOUCHER_NOT_SPONSORED|TShopBasketCore::VOUCHER_SPONSORED
+     */
+    public function getVoucherTypeCurrentlyRecalculating(): int
+    {
+        return $this->voucherTypeCurrentlyRecalculating;
+    }
+
+    private function setVoucherTypeCurrentlyRecalculating(int $type) {
+        $this->voucherTypeCurrentlyRecalculating = $type;
+    }
+
     protected function setBasketArticles($oArticles)
     {
         $this->oBasketArticles = $oArticles;
@@ -1538,7 +1558,6 @@ class TShopBasketCore implements IDataExtranetUserObserver, IPkgCmsSessionPostWa
             $oMessageManager->AddMessage($sMessageHandler, 'VOUCHER-ERROR-'.$cAllowUseOfVoucherResult, $aMessageData);
         } else {
             $this->GetActiveVouchers()->AddItem($oVoucher);
-            $this->GetActiveVouchers()->markAsValid($oVoucher);
             $oMessageManager->AddMessage($sMessageHandler, 'VOUCHER-ADDED', $aMessageData);
             $bVoucherAdded = true;
             $this->SetBasketRecalculationFlag();

--- a/src/ShopBundle/objects/TShopBasket/TShopBasketVoucherCoreList.class.php
+++ b/src/ShopBundle/objects/TShopBasket/TShopBasketVoucherCoreList.class.php
@@ -111,14 +111,13 @@ class TShopBasketVoucherCoreList extends TIterator
         $this->Destroy();
 
         $bInvalidVouchersFound = false;
-        $skippedVouchers = [];
         foreach ($aVoucherList as $iVoucherKey => $oVoucher) {
             // skip all vouchers that are not of the current type that is being calculated.
             if (
                 (TShopBasket::VOUCHER_NOT_SPONSORED === $oBasket->getVoucherTypeCurrentlyRecalculating() && $oVoucher->IsSponsored()) ||
                 (TShopBasket::VOUCHER_SPONSORED === $oBasket->getVoucherTypeCurrentlyRecalculating() && !$oVoucher->IsSponsored())
             ) {
-                $skippedVouchers[] = $oVoucher;
+                $this->AddItem($oVoucher);
                 continue;
             }
 
@@ -133,11 +132,6 @@ class TShopBasketVoucherCoreList extends TIterator
                 $aMessageData['iRemoveReasoneCode'] = $cVoucherAllowUseCode;
                 $oMessageManager->AddMessage($sMessangerName, 'VOUCHER-ERROR-NO-LONGER-VALID-FOR-BASKET', $aMessageData);
             }
-        }
-
-        // add the skipped vouchers back to the list
-        foreach ($skippedVouchers as $skippedVoucher) {
-            $this->AddItem($skippedVoucher);
         }
 
         if ($bInvalidVouchersFound) {

--- a/src/ShopBundle/objects/TShopBasket/TShopBasketVoucherCoreList.class.php
+++ b/src/ShopBundle/objects/TShopBasket/TShopBasketVoucherCoreList.class.php
@@ -12,8 +12,6 @@
 class TShopBasketVoucherCoreList extends TIterator
 {
 
-    private $checkedAndValid = [];
-
     /**
      * Adds a voucher to the list. note that it wil not check if the voucher is valid (this must be done by the calling method)
      * Returns the voucher key generated when adding the voucher.
@@ -88,22 +86,6 @@ class TShopBasketVoucherCoreList extends TIterator
         return $dValue;
     }
 
-    // allRemoveRunsDone should be called as soon as all calls to RemoveInvalidVouchers are done for one recalculation
-    public function allRemoveRunsDone()
-    {
-        $this->checkedAndValid = [];
-    }
-
-    // markAsValid will prevent a voucher from being checked until the next call to allRemoveRunsDone
-    // This is used when a voucher is checked and added outside of this class, like in \TShopBasketCore::AddVoucher.
-    // AddVoucher will check if the use of the voucher is allowed and if it is, we do not want to check it here again
-    // at the next recalculation of the basket.
-    // This fixes https://github.com/chameleon-system/chameleon-system/issues/540
-    public function markAsValid(TdbShopVoucher $voucher)
-    {
-        $this->checkedAndValid[] = $voucher->id;
-    }
-
     /**
      * Removes all vouchers from the basket, that are not valid based on the contents of the basket and the current user
      * Returns the number of vouchers removed.
@@ -128,23 +110,21 @@ class TShopBasketVoucherCoreList extends TIterator
         $aVoucherList = $this->_items;
         $this->Destroy();
 
-        // we re-add all already checked vouchers as we will ignore them in the checks later.
-        foreach ($aVoucherList as $voucher) {
-            if (in_array($voucher->id, $this->checkedAndValid, true)) {
-                $this->AddItem($voucher);
-            }
-        }
         $bInvalidVouchersFound = false;
+        $skippedVouchers = [];
         foreach ($aVoucherList as $iVoucherKey => $oVoucher) {
-            if (in_array($voucher->id, $this->checkedAndValid, true)) {
+            // skip all vouchers that are not of the current type that is being calculated.
+            if (
+                (TShopBasket::VOUCHER_NOT_SPONSORED === $oBasket->getVoucherTypeCurrentlyRecalculating() && $oVoucher->IsSponsored()) ||
+                (TShopBasket::VOUCHER_SPONSORED === $oBasket->getVoucherTypeCurrentlyRecalculating() && !$oVoucher->IsSponsored())
+            ) {
+                $skippedVouchers[] = $oVoucher;
                 continue;
             }
-            /** @var $oVoucher TdbShopVoucher */
+
             $cVoucherAllowUseCode = $oVoucher->AllowUseOfVoucher();
             if (TdbShopVoucher::ALLOW_USE == $cVoucherAllowUseCode) {
                 $this->AddItem($oVoucher);
-                // we remember all already successfully checked vouchers so we do not recheck them in second runs.
-                $this->markAsValid($oVoucher);
             } else {
                 $bInvalidVouchersFound = true;
                 $this->RemoveInvalidVoucherHook($oVoucher, $oBasket);
@@ -153,6 +133,11 @@ class TShopBasketVoucherCoreList extends TIterator
                 $aMessageData['iRemoveReasoneCode'] = $cVoucherAllowUseCode;
                 $oMessageManager->AddMessage($sMessangerName, 'VOUCHER-ERROR-NO-LONGER-VALID-FOR-BASKET', $aMessageData);
             }
+        }
+
+        // add the skipped vouchers back to the list
+        foreach ($skippedVouchers as $skippedVoucher) {
+            $this->AddItem($skippedVoucher);
         }
 
         if ($bInvalidVouchersFound) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#540
| License       | MIT

Yet another approach at finally fixing the recalculation of the vouchers. In this approach we no longer remember already valid vouchers, but instead set the type that is currently being calculated and skip all vouchers that are not of that type.

We need to set the type in the basket because we cannot alter signature of the method to provide it with an optional filter since this would introduce a bc break.
