### PR TITLE
ref:588 getPayPalLogger used as LoggerService

### DIFF
--- a/src/ShopBundle/objects/db/TShopPaymentHandler/TShopPaymentHandlerPayPal_PayViaLink.class.php
+++ b/src/ShopBundle/objects/db/TShopPaymentHandler/TShopPaymentHandlerPayPal_PayViaLink.class.php
@@ -130,7 +130,7 @@ class TShopPaymentHandlerPayPal_PayViaLink extends TdbShopPaymentHandler
      */
     public function ProcessIPNRequest($oOrder, $aURLParameter)
     {
-        $logger = $this->getLogger();
+        $logger = $this->getPaypalLogger();
 
         $sPayPalURL = $this->GetConfigParameter('url');
         $sPayPalURL = str_replace(array('https://', 'http://'), '', $sPayPalURL);
@@ -376,7 +376,10 @@ class TShopPaymentHandlerPayPal_PayViaLink extends TdbShopPaymentHandler
         return ServiceLocator::get('chameleon_system_core.util.url');
     }
 
-    private function getLogger(): LoggerInterface
+    /**
+     * @return LoggerInterface
+     */
+    private function getPaypalLogger(): LoggerInterface
     {
         return ServiceLocator::get('monolog.logger.order');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.3.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes 
| Fixed issues  | chameleon-system/chameleon-system#588
| License       | MIT

TShopPaymentHandlerPayPal_PayViaLink::getLogger replaced with ::getPayPalLogger()

