### PR TITLE
ref #613: fix paypal ipn handling

### DIFF
--- a/src/ShopBundle/objects/db/TShopPaymentHandler/TShopPaymentHandlerPayPal_PayViaLink.class.php
+++ b/src/ShopBundle/objects/db/TShopPaymentHandler/TShopPaymentHandlerPayPal_PayViaLink.class.php
@@ -318,10 +318,8 @@ class TShopPaymentHandlerPayPal_PayViaLink extends TdbShopPaymentHandler
                 ->setUser(null)
                 ->setPassword(null);
 
-            $response = $oToHostHandler->executeRequest();
-            $response = \substr($response, \strpos($response, "\r\n\r\n") + 4);
+            return $oToHostHandler->executeRequest();
 
-            return $oToHostHandler->getLastResponseHeader().$response;
         } catch (TPkgCmsException_Log $e) {
             return '';
         }


### PR DESCRIPTION
the method used to send data to paypal already returns only the body of the response.

| Q             | A
| ------------- | ---
| Branch        | 7.0.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#613
| License       | MIT

Error was introduced when removing deprecated code - hence the fix is only for 7.0.x