### PR TITLE
622: skip params that cannot be rendered

### DIFF
--- a/src/ShopBundle/Basket/BasketVariableReplacer.php
+++ b/src/ShopBundle/Basket/BasketVariableReplacer.php
@@ -65,18 +65,21 @@ final class BasketVariableReplacer
         $paramsToRender = $this->filterKeys($queryParameters, [\MTShopBasketCoreEndpoint::URL_REQUEST_PARAMETER]);
         $paramsToRender = $this->flattenQueryParameters($paramsToRender);
 
-        try {
-            $hiddenFieldsHtml = $this->twigEnvironment->render(
-                self::HIDDEN_FIELDS_SNIPPET,
-                ['values' => $paramsToRender]
-            );
-            \TTools::AddStaticPageVariables([self::BASKET_HIDDEN_FIELDS_PLACEHOLDER => $hiddenFieldsHtml]);
-        } catch(Error $error) {
-            $this->logger->error(
-                sprintf('Error rendering hidden fields for basket forms: %s', $error->getMessage()),
-                ['exception' => $error]
-            );
+        $hiddenFieldsHtml = [];
+        foreach ($paramsToRender as $name => $value ) {
+            try {
+                $hiddenFieldsHtml[] = $this->twigEnvironment->render(
+                    self::HIDDEN_FIELDS_SNIPPET,
+                    ['name' => $name, 'value' => $value]
+                );
+            } catch(Error $error) {
+                $this->logger->error(
+                    sprintf('Error rendering hidden field for basket forms. %s => %s, Error: %s', $name, $value, $error->getMessage()),
+                    ['exception' => $error]
+                );
+            }
         }
+        \TTools::AddStaticPageVariables([self::BASKET_HIDDEN_FIELDS_PLACEHOLDER => implode('', $hiddenFieldsHtml)]);
     }
 
     /**

--- a/src/ShopBundle/Resources/views/snippets/ShopBundle/BasketForm/hiddenBasketFields.html.twig
+++ b/src/ShopBundle/Resources/views/snippets/ShopBundle/BasketForm/hiddenBasketFields.html.twig
@@ -1,3 +1,1 @@
-{% for name, value in values %}
 <input type="hidden" name="{{name | e('html_attr')}}" value="{{value | e('html_attr')}}" />
-{% endfor %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.0.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no 
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#622
| License       | MIT

In case of an error rendering a parameter, this error will be logged and the parameter will be skipped. This prevents the process to give up entirely on error and to not replace the placeholder at all.

