### PR TITLE
react to new pre-output-event

### DIFF
--- a/src/ShopBundle/Resources/config/services.xml
+++ b/src/ShopBundle/Resources/config/services.xml
@@ -284,7 +284,7 @@
             <argument type="service" id="twig"/>
             <argument type="service" id="logger" on-invalid="ignore"/>
             <tag name="monolog.logger" channel="request"/>
-            <tag name="kernel.event_listener" event="kernel.request" method="handleRequest" priority="253"/>
+            <tag name="kernel.event_listener" event="chameleon_system_core.pre_output" method="handleContentOutput" priority="253"/>
         </service>
 
     </services>

--- a/src/ShopBundle/Resources/views/snippets/ShopBundle/BasketForm/hiddenBasketFields.html.twig
+++ b/src/ShopBundle/Resources/views/snippets/ShopBundle/BasketForm/hiddenBasketFields.html.twig
@@ -1,3 +1,1 @@
-{% for name, value in values %}
 <input type="hidden" name="{{name | e('html_attr')}}" value="{{value | e('html_attr')}}" />
-{% endfor %}


### PR DESCRIPTION
fixes #620

| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no  
| Deprecations? | yes
| Tests pass?   | yes 
| Fixed issues  | chameleon-system/chameleon-system#620
| License       | MIT

The replacer now uses the new pre-output-event to only replace the basket variables if there is a need to do so.
