### PR TITLE
629 only collect parameters when necessary

### DIFF
--- a/src/ShopBundle/Basket/BasketVariableReplacer.php
+++ b/src/ShopBundle/Basket/BasketVariableReplacer.php
@@ -72,7 +72,7 @@ final class BasketVariableReplacer
     public function filterResponse(FilterResponseEvent $event): void
     {
         $content = $event->getContent();
-        if (strpos($content, self::BASKET_HIDDEN_FIELDS_PLACEHOLDER) === false) {
+        if (false === strpos($content, self::BASKET_HIDDEN_FIELDS_PLACEHOLDER)) {
             return;
         }
 
@@ -83,10 +83,11 @@ final class BasketVariableReplacer
             $this->logger->info(
                 sprintf('Could not render hidden fields for basket forms. Request was null.')
             );
+
             return;
         }
 
-        if ($this->paramsRuntimeCache === null) {
+        if (null === $this->paramsRuntimeCache) {
 
             $queryParameters = $request->query->all();
             $this->paramsRuntimeCache = $this->filterKeys($queryParameters, [\MTShopBasketCoreEndpoint::URL_REQUEST_PARAMETER]);

--- a/src/ShopBundle/Basket/BasketVariableReplacer.php
+++ b/src/ShopBundle/Basket/BasketVariableReplacer.php
@@ -64,7 +64,7 @@ final class BasketVariableReplacer
     }
 
     /**
-     * handleContentOutput will be invoked on chameleon_system_core.pre_output and add the hidden fields to the basket form.
+     * filterResponse will be invoked on chameleon_system_core.filter_response and add the hidden fields to the basket form.
      * On error it will log to the request channel and move on. It will not halt execution.
      *
      * @param FilterResponseEvent $event

--- a/src/ShopBundle/Basket/BasketVariableReplacer.php
+++ b/src/ShopBundle/Basket/BasketVariableReplacer.php
@@ -11,7 +11,7 @@
 
 namespace ChameleonSystem\ShopBundle\Basket;
 
-use ChameleonSystem\CoreBundle\Event\FilterResponseEvent;
+use ChameleonSystem\CoreBundle\Event\FilterContentEvent;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
@@ -64,12 +64,12 @@ final class BasketVariableReplacer
     }
 
     /**
-     * filterResponse will be invoked on chameleon_system_core.filter_response and add the hidden fields to the basket form.
+     * filterResponse will be invoked on chameleon_system_core.filter_content and add the hidden fields to the basket form.
      * On error it will log to the request channel and move on. It will not halt execution.
      *
-     * @param FilterResponseEvent $event
+     * @param FilterContentEvent $event
      */
-    public function filterResponse(FilterResponseEvent $event): void
+    public function filterResponse(FilterContentEvent $event): void
     {
         $content = $event->getContent();
         if (false === strpos($content, self::BASKET_HIDDEN_FIELDS_PLACEHOLDER)) {

--- a/src/ShopBundle/Basket/BasketVariableReplacer.php
+++ b/src/ShopBundle/Basket/BasketVariableReplacer.php
@@ -11,9 +11,9 @@
 
 namespace ChameleonSystem\ShopBundle\Basket;
 
+use ChameleonSystem\CoreBundle\Event\FilterResponseEvent;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Twig\Environment;
 use Twig\Error\Error;
 
@@ -43,40 +43,74 @@ final class BasketVariableReplacer
      * @var LoggerInterface
      */
     private $logger;
+    /**
+     * @var array
+     */
+    private $paramsRuntimeCache;
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
 
     public function __construct(
         Environment $twigEnvironment,
-        LoggerInterface $logger)
+        RequestStack $requestStack,
+        LoggerInterface $logger
+    )
     {
         $this->twigEnvironment = $twigEnvironment;
         $this->logger = $logger;
+        $this->requestStack = $requestStack;
     }
 
     /**
-     * handleRequest will be invoked on kernel.request and add the hidden fields to the replacer.
+     * handleContentOutput will be invoked on chameleon_system_core.pre_output and add the hidden fields to the basket form.
      * On error it will log to the request channel and move on. It will not halt execution.
      *
-     * @param GetResponseEvent $event
+     * @param FilterResponseEvent $event
      */
-    public function handleRequest(GetResponseEvent $event): void
+    public function filterResponse(FilterResponseEvent $event): void
     {
-        $request = $event->getRequest();
-        $queryParameters = $request->query->all();
-        $paramsToRender = $this->filterKeys($queryParameters, [\MTShopBasketCoreEndpoint::URL_REQUEST_PARAMETER]);
-        $paramsToRender = $this->flattenQueryParameters($paramsToRender);
-
-        try {
-            $hiddenFieldsHtml = $this->twigEnvironment->render(
-                self::HIDDEN_FIELDS_SNIPPET,
-                ['values' => $paramsToRender]
-            );
-            \TTools::AddStaticPageVariables([self::BASKET_HIDDEN_FIELDS_PLACEHOLDER => $hiddenFieldsHtml]);
-        } catch(Error $error) {
-            $this->logger->error(
-                sprintf('Error rendering hidden fields for basket forms: %s', $error->getMessage()),
-                ['exception' => $error]
-            );
+        $content = $event->getContent();
+        if (strpos($content, self::BASKET_HIDDEN_FIELDS_PLACEHOLDER) === false) {
+            return;
         }
+
+        $replacer = new \TPkgCmsStringUtilities_VariableInjection();
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (null === $request) {
+            $this->logger->info(
+                sprintf('Could not render hidden fields for basket forms. Request was null.')
+            );
+            return;
+        }
+
+        if ($this->paramsRuntimeCache === null) {
+
+            $queryParameters = $request->query->all();
+            $this->paramsRuntimeCache = $this->filterKeys($queryParameters, [\MTShopBasketCoreEndpoint::URL_REQUEST_PARAMETER]);
+            $this->paramsRuntimeCache = $this->flattenQueryParameters($this->paramsRuntimeCache);
+        }
+
+        $hiddenFieldsHtml = [];
+        foreach ($this->paramsRuntimeCache as $name => $value ) {
+            try {
+                $hiddenFieldsHtml[] = $this->twigEnvironment->render(
+                    self::HIDDEN_FIELDS_SNIPPET,
+                    ['name' => $name, 'value' => $value]
+                );
+            } catch(Error $error) {
+                $this->logger->error(
+                    sprintf('Error rendering hidden field for basket forms. %s => %s, Error: %s', $name, $value, $error->getMessage()),
+                    ['exception' => $error]
+                );
+            }
+        }
+
+        $content = $replacer->replace($content, [self::BASKET_HIDDEN_FIELDS_PLACEHOLDER => implode('', $hiddenFieldsHtml)]);
+
+        $event->setContent($content);
     }
 
     /**

--- a/src/ShopBundle/Resources/config/services.xml
+++ b/src/ShopBundle/Resources/config/services.xml
@@ -285,7 +285,7 @@
             <argument type="service" id="request_stack" />
             <argument type="service" id="logger" on-invalid="ignore"/>
             <tag name="monolog.logger" channel="request"/>
-            <tag name="kernel.event_listener" event="chameleon_system_core.filter_response" method="filterResponse" priority="0"/>
+            <tag name="kernel.event_listener" event="chameleon_system_core.filter_content" method="filterResponse" priority="0"/>
         </service>
 
     </services>

--- a/src/ShopBundle/Resources/config/services.xml
+++ b/src/ShopBundle/Resources/config/services.xml
@@ -282,9 +282,10 @@
                 public="true"
         >
             <argument type="service" id="twig"/>
+            <argument type="service" id="request_stack" />
             <argument type="service" id="logger" on-invalid="ignore"/>
             <tag name="monolog.logger" channel="request"/>
-            <tag name="kernel.event_listener" event="kernel.request" method="handleRequest" priority="253"/>
+            <tag name="kernel.event_listener" event="chameleon_system_core.filter_response" method="filterResponse" priority="253"/>
         </service>
 
     </services>

--- a/src/ShopBundle/Resources/config/services.xml
+++ b/src/ShopBundle/Resources/config/services.xml
@@ -285,7 +285,7 @@
             <argument type="service" id="request_stack" />
             <argument type="service" id="logger" on-invalid="ignore"/>
             <tag name="monolog.logger" channel="request"/>
-            <tag name="kernel.event_listener" event="chameleon_system_core.filter_response" method="filterResponse" priority="253"/>
+            <tag name="kernel.event_listener" event="chameleon_system_core.filter_response" method="filterResponse" priority="0"/>
         </service>
 
     </services>

--- a/src/ShopBundle/Resources/views/snippets/ShopBundle/BasketForm/hiddenBasketFields.html.twig
+++ b/src/ShopBundle/Resources/views/snippets/ShopBundle/BasketForm/hiddenBasketFields.html.twig
@@ -1,3 +1,1 @@
-{% for name, value in values %}
 <input type="hidden" name="{{name | e('html_attr')}}" value="{{value | e('html_attr')}}" />
-{% endfor %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no   
| Deprecations? | no
| Tests pass?   | yes   
| Fixed issues  | chameleon-system/chameleon-system#629
| License       | MIT

The replacer now uses the new pre-output-event to only replace the basket variables if there is a need to do so.
