### PR TITLE
Add basketUrl post render variable

### DIFF
--- a/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1604649540.inc.php
+++ b/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1604649540.inc.php
@@ -1,0 +1,8 @@
+<h1>Build #1604649540</h1>
+<h2>Date: 2020-11-06</h2>
+<div class="changelog">
+    - Add Post render variable for basket URL to prevent accidental caching of it
+</div>
+<?php
+
+TCMSLogChange::addInfoMessage('If you are using a custom theme you need replace the {{sBasketUrl}} template variable with the [{basketUrl}] post render variable in the shopBasketMiniBasket and shopBasketMiniBasketMobile templates', TCMSLogChange::INFO_MESSAGE_LEVEL_INFO);

--- a/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1604649540.inc.php
+++ b/src/ShopBundle/Bridge/Chameleon/Migration/Script/update-1604649540.inc.php
@@ -1,8 +1,8 @@
 <h1>Build #1604649540</h1>
 <h2>Date: 2020-11-06</h2>
 <div class="changelog">
-    - Add Post render variable for basket URL to prevent accidental caching of it
+    - ref #654: Show warning message about changing basket url
 </div>
 <?php
 
-TCMSLogChange::addInfoMessage('If you are using a custom theme you need replace the {{sBasketUrl}} template variable with the [{basketUrl}] post render variable in the shopBasketMiniBasket and shopBasketMiniBasketMobile templates', TCMSLogChange::INFO_MESSAGE_LEVEL_INFO);
+TCMSLogChange::addInfoMessage('If you are using a custom theme you need replace the {{sBasketUrl}} template variable with the [{basketUrl}] post render variable in the shopBasketMiniBasket and shopBasketMiniBasketMobile templates', TCMSLogChange::INFO_MESSAGE_LEVEL_WARNING);

--- a/src/ShopBundle/objects/WebModules/MTShopBasketCore/MTShopBasketCoreEndpoint.class.php
+++ b/src/ShopBundle/objects/WebModules/MTShopBasketCore/MTShopBasketCoreEndpoint.class.php
@@ -1096,6 +1096,14 @@ class MTShopBasketCoreEndpoint extends TShopUserCustomModelBase
         return $aIncludes;
     }
 
+    public function GetPostRenderVariables(): array
+    {
+        $variables = parent::GetPostRenderVariables();
+        $variables['basketUrl'] = $this->getShopService()->getBasketLink(false);
+
+        return $variables;
+    }
+
     private function getBasketItemKeyFromUserInput($aRequestData)
     {
         if (true === isset($aRequestData[self::URL_ITEM_BASKET_KEY_NAME])) {


### PR DESCRIPTION
Together chameleon-system/chameleon-shop-theme-bundle#38 this fixes chameleon-system/chameleon-system#654

| Q             | A
| ------------- | ---
| Branch        | 6.3.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | chameleon-system/chameleon-system#654
| License       | MIT

This PR adds the `basketUrl` post render variable for usage in the mini shop basket templates in order to
prevent caching of the 'continue shopping' URL.

