### PR TITLE
ref #652:  Replace named constructors with __construct

### DIFF
--- a/src/ShopRatingServiceBundle/objects/TShopAuskunftAPI.class.php
+++ b/src/ShopRatingServiceBundle/objects/TShopAuskunftAPI.class.php
@@ -15,6 +15,8 @@
 /**/
 class TShopAuskunftAPI
 {
+    use \ChameleonSystem\CoreBundle\BackwardsCompatibilityShims\NamedConstructorSupport;
+
     // XML-Parsing vars
     protected $parser;
 
@@ -34,7 +36,7 @@ class TShopAuskunftAPI
      * Constructor.
      */
     //-------------------------------------------------------------------------
-    public function TShopAuskunftAPI()
+    public function __construct()
     {
         //-------------------------------------------------------------------------
         if (!($this->parser = xml_parser_create())) {
@@ -44,6 +46,15 @@ class TShopAuskunftAPI
         xml_set_object($this->parser, $this);
         xml_set_element_handler($this->parser, 'start_tag', 'end_tag');
         xml_set_character_data_handler($this->parser, 'tag_contents');
+    }
+
+    /**
+     * @deprecated Named constructors are deprecated and will be removed with PHP8. When calling from a parent, please use `parent::__construct` instead.
+     * @see self::__construct
+     */
+    public function TShopAuskunftAPI()
+    {
+        $this->callConstructorAndLogDeprecation(func_get_args());
     }
 
     //-------------------------------------------------------------------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | yes <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | chameleon-system/chameleon-system#652   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Replaces all deprecated named constructors with __construct using the backwards compatibility shim introduced in chameleon-system/chameleon-base#525 .

chameleon-system/chameleon-base#525 must be merged before merging this PR.