### PR TITLE
685 multiselect listfilter search problem

### DIFF
--- a/src/ShopListFilterBundle/objects/db/ListfilterItems/TPkgShopListfilterItemMultiselectMLT.class.php
+++ b/src/ShopListFilterBundle/objects/db/ListfilterItems/TPkgShopListfilterItemMultiselectMLT.class.php
@@ -1,5 +1,5 @@
 <?php
-//error_reporting(0);
+
 /*
  * This file is part of the Chameleon System (https://www.chameleonsystem.com).
  *

--- a/src/ShopListFilterBundle/objects/db/ListfilterItems/TPkgShopListfilterItemMultiselectMLT.class.php
+++ b/src/ShopListFilterBundle/objects/db/ListfilterItems/TPkgShopListfilterItemMultiselectMLT.class.php
@@ -1,5 +1,5 @@
 <?php
-
+//error_reporting(0);
 /*
  * This file is part of the Chameleon System (https://www.chameleonsystem.com).
  *
@@ -21,8 +21,7 @@ class TPkgShopListfilterItemMultiselectMLT extends TPkgShopListfilterItemMultise
     {
         $sQuery = $this->GetFromInternalCache('sQueryRestrictionForActiveFilter');
         if (is_null($sQuery)) {
-            $aValues = $this->aActiveFilterData;
-            if (count($aValues) > 0) {
+            if (true === is_array($this->aActiveFilterData) && count($this->aActiveFilterData) > 0) {
                 $sItemListQuery = $this->GetSQLQueryForQueryRestrictionForActiveFilter();
                 $aIdList = array();
                 if (!empty($sItemListQuery)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.0.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes 
| Fixed issues  | chameleon-system/chameleon-system#685
| License       | MIT

- aActiveFilterData validation via is_array extended.
- $aValues inline-variable removed.
