### PR TITLE
ref #725: Replace `each` function usage with `foreach`

### DIFF
--- a/src/ShopRatingServiceBundle/objects/TShopAuskunftAPI.class.php
+++ b/src/ShopRatingServiceBundle/objects/TShopAuskunftAPI.class.php
@@ -94,7 +94,7 @@ class TShopAuskunftAPI
 
         if ('RATING' == $name) {
             if (is_array($attribs)) {
-                while (list($key, $val) = each($attribs)) {
+                foreach ($attribs as $key => $val) {
                     //echo strtolower($key)."=\"".$val."\"";
                     if ('id' === strtolower($key)) {
                         $this->aRatingItem['id'] = $val;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | chameleon-system/chameleon-system#725  <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Replaces a usage of the `each` function which was removed in PHP8 with it's `foreach` equivalent.