### PR TITLE
46264 increase filter resolution

### DIFF
--- a/src/ShopListFilterBundle/mappers/filter/TPkgShopListfilterMapper_FilterNumericSlider.class.php
+++ b/src/ShopListFilterBundle/mappers/filter/TPkgShopListfilterMapper_FilterNumericSlider.class.php
@@ -118,7 +118,12 @@ class TPkgShopListfilterMapper_FilterNumericSlider extends AbstractPkgShopListfi
 
             $stepCount = 20;
 
-            $stepSize = round(($highestArticlePrice - $lowestArticlePrice) / $stepCount);
+            $delta = $highestArticlePrice - $lowestArticlePrice;
+            $stepSize = round($delta / $stepCount);
+            if ($stepSize < 1) {
+                $stepSize = 1;
+                $stepCount = round($delta);
+            }
 
             for ($i = 0; $i <= $stepCount; ++$i) {
                 $priceOption = $lowestArticlePrice + $i * $stepSize;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed issues  | chameleon-system/chameleon-system#398
| License       | MIT

Test case (resolved):
1. Go to the demo shop.
2. Navigate via the menu "Art Prints" / "Chameleon Prints", you can see now a list of products and a price filter sidebar.
3. Deactivate some products (like "Chameleon on the finger") in the CMS until you have a product's price range between 30 € and 39 € (for example).

- The price filter range should now a range between 30 and 39 and is changeable in 1 € steps.
- Also the jQuery / Javascript error in the browser's developer console should not visible no more.
- If the difference of the min and max value is lower than 20 (Euros), the price filter step size is now fixed to 1 €.
- The existing implemented select object is considers integer values only, thus minor price values in cent are "not easy" to use (no changes were made).
