### PR TITLE
Set and reset mail notification state before and after ma…

### DIFF
--- a/src/ShopBundle/objects/db/TShopOrder.class.php
+++ b/src/ShopBundle/objects/db/TShopOrder.class.php
@@ -488,7 +488,7 @@ class TShopOrder extends TShopOrderAutoParent
      */
     public function SendOrderNotification($sSendToMail = null, $sSendToName = null)
     {
-        if ('0' === $this->sqlData['system_order_notification_send']) {
+        if ('1' === $this->sqlData['system_order_notification_send']) {
             return false;
         }
 


### PR DESCRIPTION
…il process

| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#743
| License       | MIT

This code sets the "mail sent" flag *before* sending the notification mail (and resets in a error case) to avoid processing another parallel mail notification process (works like a *semaphore*).

