### PR TITLE
ref #723: Limit element count on notice list to under 4kb string size

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "screenshotfolder_id": ""
     },
     "require": {
+        "ext-json": "*",
         "chameleon-system/chameleon-base": "~7.1.0",
         "simplepie/simplepie": "~1.3"
     },

--- a/src/ShopBundle/pkgExtranet/objects/db/TShopDataExtranetUser.class.php
+++ b/src/ShopBundle/pkgExtranet/objects/db/TShopDataExtranetUser.class.php
@@ -16,6 +16,8 @@ class TShopDataExtranetUser extends TShopDataExtranetUserAutoParent
 {
     const COOKIE_NAME_HISTORY = 'shopuserarticleviewhistory';
     const COOKIE_NAME_NOTICELIST = 'shopuserarticlenoticelist';
+    private const MAX_NOTICE_LIST_COOKIE_LENGTH = 25; // this should stay under the critical 4kb string size
+
     /**
      * the article ids last viewed by the user (ie. on the detail page) will be stored here
      * Note: the although the list may grow longer (the complete history will be saved for logged in users)
@@ -399,7 +401,7 @@ class TShopDataExtranetUser extends TShopDataExtranetUserAutoParent
                 }
                 if (is_array($aTmpList)) {
                     reset($aTmpList);
-                    foreach ($aTmpList as $iKey => $aNoticeListItemData) {
+                    foreach ($aTmpList as $aNoticeListItemData) {
                         $oNoticeListItem = TdbShopUserNoticeList::GetNewInstance();
                         $oNoticeListItem->LoadFromRow($aNoticeListItemData);
                         $this->aNoticeList[$oNoticeListItem->fieldShopArticleId] = $oNoticeListItem->sqlData;
@@ -409,8 +411,9 @@ class TShopDataExtranetUser extends TShopDataExtranetUserAutoParent
         }
 
         $noticeList = array();
-        foreach ($this->aNoticeList as $articleId => $item) {
-            $noticeList[$articleId] = TdbShopUserNoticeList::GetNewInstance($item);
+        foreach ($this->aNoticeList as $item) {
+            $item = TdbShopUserNoticeList::GetNewInstance($item);
+            $noticeList[$item->fieldShopArticleId] = $item;
         }
 
         return $noticeList;
@@ -442,7 +445,11 @@ class TShopDataExtranetUser extends TShopDataExtranetUserAutoParent
         } else {
             $oNoticeListItem = TdbShopUserNoticeList::GetNewInstance();
             /** @var $oNoticeListItem TdbShopUserNoticeList */
-            $aData = array('shop_article_id' => $iArticleId, 'date_added' => date('Y-m-d H:i:s'), 'data_extranet_user_id' => $this->id, 'amount' => $iAmount);
+            $aData = [
+                'shop_article_id' => $iArticleId,
+                'date_added' => date('Y-m-d H:i:s'),
+                'amount' => $iAmount,
+            ];
             $oNoticeListItem->LoadFromRow($aData);
             if (!is_null($this->id) && $this->IsLoggedIn()) {
                 $oNoticeListItem->Save();
@@ -479,8 +486,17 @@ class TShopDataExtranetUser extends TShopDataExtranetUserAutoParent
     {
         $aNoticeList = array();
         reset($this->aNoticeList);
+        $counter = 0;
         foreach (array_keys($this->aNoticeList) as $iItemId) {
-            $aNoticeList[$iItemId] = $this->aNoticeList[$iItemId];
+            if ($counter++ >= self::MAX_NOTICE_LIST_COOKIE_LENGTH) {
+                break;
+            }
+
+            $aNoticeList[] = [
+                'shop_article_id' => $this->aNoticeList[$iItemId]['shop_article_id'],
+                'date_added' => $this->aNoticeList[$iItemId]['date_added'],
+                'amount' => $this->aNoticeList[$iItemId]['amount'],
+            ];
         }
         $sNoticeList = json_encode($aNoticeList);
         $sNoticeList = base64_encode($sNoticeList);

--- a/src/ShopBundle/pkgExtranet/objects/db/TShopDataExtranetUser.class.php
+++ b/src/ShopBundle/pkgExtranet/objects/db/TShopDataExtranetUser.class.php
@@ -16,7 +16,7 @@ class TShopDataExtranetUser extends TShopDataExtranetUserAutoParent
 {
     const COOKIE_NAME_HISTORY = 'shopuserarticleviewhistory';
     const COOKIE_NAME_NOTICELIST = 'shopuserarticlenoticelist';
-    private const MAX_NOTICE_LIST_COOKIE_LENGTH = 25; // this should stay under the critical 4kb string size
+    private const MAX_NOTICE_LIST_COOKIE_LENGTH = 17; // this should stay under the critical 4kb string size
 
     /**
      * the article ids last viewed by the user (ie. on the detail page) will be stored here
@@ -448,6 +448,7 @@ class TShopDataExtranetUser extends TShopDataExtranetUserAutoParent
             $aData = [
                 'shop_article_id' => $iArticleId,
                 'date_added' => date('Y-m-d H:i:s'),
+                'data_extranet_user_id' => $this->id,
                 'amount' => $iAmount,
             ];
             $oNoticeListItem->LoadFromRow($aData);
@@ -495,6 +496,7 @@ class TShopDataExtranetUser extends TShopDataExtranetUserAutoParent
             $aNoticeList[] = [
                 'shop_article_id' => $this->aNoticeList[$iItemId]['shop_article_id'],
                 'date_added' => $this->aNoticeList[$iItemId]['date_added'],
+                'data_extranet_user_id' => $this->aNoticeList[$iItemId]['data_extranet_user_id'],
                 'amount' => $this->aNoticeList[$iItemId]['amount'],
             ];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#723
| License       | MIT
