### PR TITLE
fix active product retrieval if no request stack available

### DIFF
--- a/src/ShopBundle/Service/ShopService.php
+++ b/src/ShopBundle/Service/ShopService.php
@@ -144,7 +144,12 @@ class ShopService implements ShopServiceInterface
      */
     public function getActiveProduct()
     {
-        return $this->requestStack->getCurrentRequest()->attributes->get('activeShopArticle', null);
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            return null;
+        }
+
+        return $request->attributes->get('activeShopArticle');
     }
 
     /**
@@ -152,13 +157,12 @@ class ShopService implements ShopServiceInterface
      */
     public function getActiveCategory()
     {
-        $activeCategory = null;
         $request = $this->requestStack->getCurrentRequest();
-        if (null !== $request) {
-            $activeCategory = $request->attributes->get('activeShopCategory');
+        if (null === $request) {
+            return null;
         }
 
-        return $activeCategory;
+        return $request->attributes->get('activeShopCategory');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | 
| License       | MIT

\ChameleonSystem\ShopBundle\Service\ShopService::getActiveProduct
did not check for existing requestStack like other methods in this class already do.
now it will and resulting errors prior to fix won't occur anymore.

