### PR TITLE
ref #801 do not allow multiple vouchers from same series if option "A…

### DIFF
--- a/src/ShopBundle/objects/db/TShopVoucher.class.php
+++ b/src/ShopBundle/objects/db/TShopVoucher.class.php
@@ -272,6 +272,14 @@ class TShopVoucher extends TShopVoucherAutoParent
                     $bAllowUse = TdbShopVoucher::USE_ERROR_CUSTOMER_USED_VOUCHER_SERIES_BEFORE;
                 }
             }
+
+            $matchingVoucherFromSameSeries = $oExistingVouchers->FindItemWithProperty(
+                'fieldShopVoucherSeriesId',
+                $this->fieldShopVoucherSeriesId
+            );
+            if (false !== $matchingVoucherFromSameSeries) {
+                $bAllowUse = TdbShopVoucher::USE_ERROR_CUSTOMER_USED_VOUCHER_SERIES_BEFORE;
+            }
         }
 
         // if the voucher may only be used with the first order, check if the user has ordered before


### PR DESCRIPTION
…llow only one voucher per user" was set

| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed issues  | chameleon-system/chameleon-system#801
| License       | MIT

<!--
If option "Allow only one per user" is set within voucher series, do not allow adding multiple vouchers from this series to an order.
-->

