### PR TITLE
810 canonical url on product list pages contains empty listpage parameter

### DIFF
--- a/src/ShopBundle/objects/WebModules/MTShopPageMetaCore/MTShopPageMetaCore.class.php
+++ b/src/ShopBundle/objects/WebModules/MTShopPageMetaCore/MTShopPageMetaCore.class.php
@@ -261,7 +261,7 @@ class MTShopPageMetaCore extends MTPageMetaCore
             if ($category) {
                 $currentPage = $this->getInputFilterUtil()->getFilteredInput(TdbShopArticleList::URL_LIST_CURRENT_PAGE, 0);
                 $additionalParam = array();
-                if (0 !== $currentPage) {
+                if ('0' !== $currentPage && 0 !== $currentPage) {
                     $additionalParam = array(TdbShopArticleList::URL_LIST_CURRENT_PAGE => $currentPage);
                 }
                 $activePage = $this->getActivePageService()->getActivePage();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.1.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | chameleon-system/chameleon-system#810
| License       | MIT

