### PR TITLE
ref #825: add id field for table structure like search index tables

### DIFF
--- a/src/SearchBundle/objects/db/TShopSearchIndexer.class.php
+++ b/src/SearchBundle/objects/db/TShopSearchIndexer.class.php
@@ -631,7 +631,9 @@ class TShopSearchIndexer extends TShopSearchIndexerAutoParent
                 }
             }
             if (count($manualArticleSelection) > 0) {
-                $query = "SELECT `shop_article`.`id` AS shop_article_id,
+                $query = "SELECT
+                            0 as id,
+                            `shop_article`.`id` AS shop_article_id,
                            'xxx' substring,
                            '".$sLanguageId."' cms_language_id,
                            1 AS occurrences,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 7.0.x for bug fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed issues  | chameleon-system/chameleon-system#825
| License       | MIT

This commit fixes the exception error after a table row for the search index tables was added about a year ago (@see #117).
The corresponding sql query for custom keywords has to be the same structure and column row count as the queries for the index tables, thus a missing row was also added (just a dummy value).

Note: If an article does not be shown - but without an error - then the chosen connected article is not flagged as a "Mabuse article" - so it is not an error at all.
Technical said, the condition is 
``shop_article`.`active` = '1' AND `shop_article`.`variant_parent_is_active` = '1'  AND `shop_article`.`variant_parent_id` = ''  AND `shop_article`.`virtual_article` = '0' AND `shop_article`.`is_searchable` = '1' AND `shop_article`.`is_mabuse_product` = '1'`

The underlying _SearchBundle_ is not part of Chameleon ver. 7.1.
```

